### PR TITLE
Add lightweight reporting tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Database settings
+DB_USER=youruser
+DB_PASSWORD=yourpass
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=yourdb
+
+# SMTP settings
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your_email@example.com
+SMTP_PASSWORD=your_email_password
+
+# Report settings
+STAKEHOLDER_EMAILS=user1@example.com,user2@example.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.env
+*.sqlite

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Python Reporter
+
+This project demonstrates a lightweight reporting tool that connects to a PostgreSQL database, aggregates data per stakeholder, generates Excel reports and emails them on a schedule.
+
+## Setup
+
+1. Create a Python virtual environment and install dependencies:
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+2. Copy `.env.example` to `.env` and fill in your database and SMTP credentials.
+
+3. Run the scheduler:
+
+```bash
+python main.py
+```
+
+The scheduler is configured to run daily at 9am by default.

--- a/db.py
+++ b/db.py
@@ -1,0 +1,25 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from dotenv import load_dotenv
+import logging
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+DB_USER = os.getenv('DB_USER')
+DB_PASSWORD = os.getenv('DB_PASSWORD')
+DB_HOST = os.getenv('DB_HOST', 'localhost')
+DB_PORT = os.getenv('DB_PORT', '5432')
+DB_NAME = os.getenv('DB_NAME')
+
+DATABASE_URL = f"postgresql+psycopg2://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(bind=engine)
+
+
+def get_session():
+    """Return a new SQLAlchemy session."""
+    return SessionLocal()

--- a/mailer.py
+++ b/mailer.py
@@ -1,0 +1,34 @@
+import os
+import smtplib
+from email.message import EmailMessage
+import logging
+from dotenv import load_dotenv
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+SMTP_HOST = os.getenv('SMTP_HOST')
+SMTP_PORT = int(os.getenv('SMTP_PORT', '587'))
+SMTP_USER = os.getenv('SMTP_USER')
+SMTP_PASSWORD = os.getenv('SMTP_PASSWORD')
+
+
+def send_mail(to_address: str, subject: str, body: str, attachment_path: str) -> None:
+    """Send an email with an attachment."""
+    msg = EmailMessage()
+    msg['Subject'] = subject
+    msg['From'] = SMTP_USER
+    msg['To'] = to_address
+    msg.set_content(body)
+
+    with open(attachment_path, 'rb') as f:
+        data = f.read()
+        msg.add_attachment(data, maintype='application', subtype='octet-stream', filename=os.path.basename(attachment_path))
+
+    logger.info("Sending email to %s", to_address)
+    with smtplib.SMTP(SMTP_HOST, SMTP_PORT) as server:
+        server.starttls()
+        server.login(SMTP_USER, SMTP_PASSWORD)
+        server.send_message(msg)
+    logger.info("Email sent to %s", to_address)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,7 @@
+import logging
+from scheduler import schedule_jobs
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+if __name__ == '__main__':
+    schedule_jobs()

--- a/report.py
+++ b/report.py
@@ -1,0 +1,57 @@
+import logging
+from typing import List, Dict
+from sqlalchemy import text
+from openpyxl import Workbook
+from openpyxl.utils import get_column_letter
+from openpyxl.styles import Font
+
+from db import get_session
+
+logger = logging.getLogger(__name__)
+
+QUERY = text(
+    """
+    SELECT region, SUM(amount) AS total_sales
+    FROM sales
+    WHERE stakeholder_email = :email
+    GROUP BY region
+    ORDER BY region
+    """
+)
+
+
+def fetch_sales_by_region(email: str) -> List[Dict]:
+    """Fetch aggregated sales data for a stakeholder."""
+    logger.info("Fetching sales data for %s", email)
+    with get_session() as session:
+        result = session.execute(QUERY, {"email": email})
+        rows = [{"region": r[0], "total_sales": r[1]} for r in result]
+    return rows
+
+
+def create_excel(data: List[Dict], path: str) -> None:
+    """Generate an Excel report with totals and header styling."""
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Sales by Region"
+
+    headers = ["Region", "Total Sales"]
+    ws.append(headers)
+    for cell in ws[1]:
+        cell.font = Font(bold=True)
+
+    total = 0
+    for row in data:
+        ws.append([row["region"], row["total_sales"]])
+        total += row["total_sales"]
+
+    ws.append(["Total", total])
+    ws[f"A{ws.max_row}"].font = Font(bold=True)
+
+    # Auto-width columns
+    for column in range(1, ws.max_column + 1):
+        length = max(len(str(cell.value)) for cell in ws[get_column_letter(column)]) + 2
+        ws.column_dimensions[get_column_letter(column)].width = length
+
+    wb.save(path)
+    logger.info("Saved report to %s", path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+SQLAlchemy>=1.4
+psycopg2-binary
+openpyxl
+APScheduler
+python-dotenv

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,34 @@
+import os
+import logging
+from apscheduler.schedulers.blocking import BlockingScheduler
+from dotenv import load_dotenv
+
+from report import fetch_sales_by_region, create_excel
+from mailer import send_mail
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+stakeholder_emails = [e.strip() for e in os.getenv('STAKEHOLDER_EMAILS', '').split(',') if e.strip()]
+
+scheduler = BlockingScheduler()
+
+
+def job():
+    for email in stakeholder_emails:
+        data = fetch_sales_by_region(email)
+        report_path = f"report_{email.replace('@', '_')}.xlsx"
+        create_excel(data, report_path)
+        send_mail(
+            to_address=email,
+            subject="Daily Sales Report",
+            body="Please find attached your daily sales report.",
+            attachment_path=report_path,
+        )
+
+
+def schedule_jobs():
+    scheduler.add_job(job, 'cron', hour=9, minute=0)
+    logger.info("Scheduler configured to run daily at 9am")
+    scheduler.start()


### PR DESCRIPTION
## Summary
- add modules for DB access, report generation, email sending, scheduling and main entrypoint
- provide sample configuration and README
- manage dependencies

## Testing
- `python -m py_compile db.py report.py mailer.py scheduler.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6883194763c88330a010aae77dde2d57